### PR TITLE
added suport for the contructor to take in a bignum

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,14 @@ var bigint = module.exports = function(int, base) {
 };
 
 function BigNum(str, base) {
-  if(typeof str === 'number') str = str.toString()
-  this._jsbn = new jsbn(str, base || 10);
+  if (str && str._jsbn) {
+    this._jsbn = str._jsbn;
+  } else {
+    if (typeof str === 'number') {
+      str = str.toString();
+    }
+    this._jsbn = new jsbn(str, base || 10);
+  }
 }
 
 function fromJsbn(n) {
@@ -64,6 +70,9 @@ BigNum.prototype = {
   },
   toString: function(base) {
     return this._jsbn.toString(base);
+  },
+  toNumber: function(){
+    return parseInt(this._jsbn.toString());
   }
 };
 
@@ -77,7 +86,6 @@ var binOps = {
   pow: 'pow',
   xor: 'xor',
   and: 'and',
-  xor: 'xor',
   shiftLeft: 'shiftLeft',
   shiftRight: 'shiftRight'
 };

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,13 @@ test('implicit base', function(t) {
   });
 });
 
+
+assertSame('contructor', function(bigint, cb) {
+  var ba = bigint(a, 16);
+  var bb = bigint(ba);
+  cb(null, bb.toString());
+});
+
 // slow operations: use smaller numbers
 
 assertSame('pow', function(bigint, cb) {
@@ -79,7 +86,6 @@ for(var i=0; i<(a.lenth*4); i++) {
 }
 
 // comparisons
-
 assertSame('eq', function(bigint, cb) {
   var ba = bigint(a, 16);
   var bb = bigint(b, 16);
@@ -116,4 +122,9 @@ assertSame('toBuffer', function(bigint, cb) {
 assertSame('fromBuffer', function(bigint, cb) {
   var ba = bigint(a, 16);
   cb(null, bigint.fromBuffer(ba.toBuffer()).toString(16));
+});
+
+assertSame('toString', function(bigint, cb) {
+  var ba = bigint(a, 16);
+  cb(null, ba.toString());
 });


### PR DESCRIPTION
with bignum you can do

```
var a = bignum(8)
var b = bignum(a)

console.log(b.toNumber())  // 8

```

this adds support for this behavoir.
